### PR TITLE
Add autoscaling group for self-healing and multi-az deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ module "aws_connector" {
 }
 ```
 
+For self-healing ASG deployment:
+```hcl
+module "aws_connector" {
+  source                 = "banyansecurity/banyan-connector/aws"
+  
+  name                   = "my-banyan-connector"
+  vpc_id                 = "vpc-0e73afd7c24062f0a"
+  asg_subnets            = ["subnet-00e393f22c3f09e16","subnet-01ef94f23c2e08f20"]
+  asg_enabled            = true
+  member_security_groups = [aws_security_group.allow_conn.id]
+}
+```
+
 
 ## Notes
 

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,14 @@
+## If multiple subnets are provided in a single AZ, the LB will fail to create
+## Find one subnet from each AZ and use those instead
+data "aws_subnet" "selected" {
+  count = length(var.asg_subnet_ids)
+  id    = var.asg_subnet_ids[count.index]
+}
+
+locals {
+  # Group subnet IDs by their availability zones
+  subnet_groups = { for s in data.aws_subnet.selected : s.availability_zone => s.id... }
+
+  # Select one subnet ID per availability zone
+  one_subnet_per_az = [for az, subnets in local.subnet_groups : subnets[0]]
+}

--- a/main.tf
+++ b/main.tf
@@ -36,8 +36,8 @@ resource "aws_security_group" "connector_sg" {
   }
 
   ingress {
-    from_port = 9094
-    to_port   = 9094
+    from_port = 9443
+    to_port   = 9443
     protocol  = "tcp"
     self      = true
   }
@@ -147,7 +147,7 @@ resource "aws_lb_target_group" "connector_tg" {
   health_check {
     protocol            = "TCP"
     port                = "traffic-port"
-    healthy_threshold   = 3
+    healthy_threshold   = 2
     unhealthy_threshold = 3
     interval            = 30
   }

--- a/main.tf
+++ b/main.tf
@@ -1,19 +1,19 @@
 locals {
   tags = merge(var.tags, {
     Provider = "Banyan"
-    Name = "${var.name}-banyan-connector"
+    Name     = "${var.name}-banyan-connector"
   })
 }
 
 data "aws_ami" "ubuntu" {
   most_recent = true
-  owners = ["099720109477"] # Canonical
+  owners      = ["099720109477"] # Canonical
 
   filter {
     name   = "name"
     values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
   }
-  
+
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
@@ -28,20 +28,20 @@ resource "aws_security_group" "connector_sg" {
   tags = local.tags
 
   ingress {
-    from_port         = 22
-    to_port           = 22
-    protocol          = "tcp"
-    cidr_blocks       = var.management_cidrs
-    description       = "Management"
-  }  
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.management_cidrs
+    description = "Management"
+  }
 
   egress {
-    from_port         = 0
-    to_port           = 0
-    protocol          = "-1"
-    cidr_blocks       = ["0.0.0.0/0"]
-    ipv6_cidr_blocks  = ["::/0"]    
-    description       = "Banyan Global Edge network"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+    description      = "Banyan Global Edge network"
 
   }
 }
@@ -74,18 +74,72 @@ echo 'connector_name: ${var.name}' >> connector-config.yaml
 INIT_SCRIPT
 }
 
-resource "aws_instance" "connector_vm" {
-  ami             = data.aws_ami.ubuntu.id
+resource "aws_launch_configuration" "connector_config" {
+  count           = var.asg_enabled ? 1 : 0
+  name_prefix     = "connector-${var.name}-${random_string.random.result}-"
+  image_id        = data.aws_ami.ubuntu.id
   instance_type   = var.instance_type
   key_name        = var.ssh_key_name
+  user_data       = local.init_script
+  security_groups = concat([aws_security_group.connector_sg.id], var.member_security_groups)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "connector_asg" {
+  count                = var.asg_enabled ? 1 : 0
+  launch_configuration = aws_launch_configuration.connector_config[0].id
+  vpc_zone_identifier  = [var.asg_subnet_ids]
+  min_size             = 1
+  max_size             = 1
+  desired_capacity     = 1
+
+  tag {
+    key                 = "Name"
+    value               = "connector-instance-${var.name}"
+    propagate_at_launch = true
+  }
+
+  health_check_type         = "EC2"
+  health_check_grace_period = 300
+  force_delete              = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_target_group" "connector_tg" {
+  count    = var.asg_enabled ? 1 : 0
+  name     = "connector-tg"
+  port     = 9443
+  protocol = "TCP"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    protocol            = "TCP"
+    port                = "traffic-port"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    interval            = 30
+  }
+}
+
+resource "aws_instance" "connector_vm" {
+  var.asg_enabled ? 0 : 1
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+  key_name      = var.ssh_key_name
 
   tags = local.tags
 
   vpc_security_group_ids = concat([aws_security_group.connector_sg.id], var.member_security_groups)
-  subnet_id = var.subnet_id
+  subnet_id              = var.subnet_id
 
-  monitoring      = true
-  ebs_optimized   = true
+  monitoring    = true
+  ebs_optimized = true
 
   ephemeral_block_device {
     device_name  = "/dev/sdc"

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,7 @@ variable "vpc_id" {
 
 variable "subnet_id" {
   type        = string
+  default     = ""
   description = "ID of the subnet where the connector instance should be created"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -23,13 +23,13 @@ variable "cluster" {
 }
 
 variable "tunnel_private_domains" {
-  type = list(string)
+  type        = list(string)
   description = "Any internal domains that can only be resolved on your internal network’s private DNS"
   default     = null
 }
 
 variable "tunnel_cidrs" {
-  type = list(string)
+  type        = list(string)
   description = "Backend CIDR Ranges that correspond to the IP addresses in your private network(s)"
   default     = null
 }
@@ -43,6 +43,12 @@ variable "vpc_id" {
 variable "subnet_id" {
   type        = string
   description = "ID of the subnet where the connector instance should be created"
+}
+
+variable "asg_subnet_ids" {
+  type        = list(string)
+  description = "List of subnet IDs for the autoscaling group. Required when asg_enabled == true"
+  default     = []
 }
 
 variable "ssh_key_name" {
@@ -70,7 +76,13 @@ variable "tags" {
 }
 
 variable "member_security_groups" {
-  type    = list(string)
+  type        = list(string)
   description = "Additional security groups which the access tier should be a member of"
-  default = []
+  default     = []
+}
+
+variable "asg_enabled" {
+  type        = bool
+  description = "Enable autoscaling group for the connector, enables self-healing"
+  default     = false
 }


### PR DESCRIPTION
Create an autoscaling group, as well as a target group and dummy load balancer for health checks to port 9443. 

This enables a single instance that can fail over to another availability zone or re-provision the instance if the connector process stops working

Resolves https://github.com/banyansecurity/terraform-aws-banyan-connector/issues/2